### PR TITLE
refactor: use prettier as an implementation of formatting markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/codemirror": "^0.0.108",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.32",
+    "@types/prettier": "^2.2.3",
     "chalk": "^4.1.0",
     "copy-webpack-plugin": "^6.1.0",
     "fs-extra": "^9.0.1",
@@ -28,5 +29,8 @@
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
     "yargs": "^16.2.0"
+  },
+  "dependencies": {
+    "prettier": "^2.3.0"
   }
 }

--- a/src/TableFormatter.ts
+++ b/src/TableFormatter.ts
@@ -1,31 +1,37 @@
-import { Editor } from "codemirror";
-import formatTable from "../lib/FormatTable";
+import {Editor} from 'codemirror'
+import formatTable from '../lib/FormatTable'
+import prettier from 'prettier'
 
 module.exports = {
-	default: function(_context: any) {
+  default: function (_context: any) {
 
-		const plugin = function(CodeMirror) {
-			CodeMirror.defineExtension('formatTable', function() {
-				const cm: Editor = this; // to get autocomplete working
+    const plugin = function (CodeMirror) {
+      CodeMirror.defineExtension('formatTable', function () {
+        const editor: Editor = this // to get autocomplete working
 
-				const cursor = cm.getCursor();
-				let startLine = cursor.line;
-				while (startLine >=0 && cm.getLine(startLine).trimStart().charAt(0) === '|') startLine--;
-				startLine++;
+        let parser = 'markdown' // for JS. Other values: json, typescript, css, scss, less, html (also for xml), yaml or php
 
-				let endLine = cursor.line;
-				while (!!cm.getLine(endLine) && cm.getLine(endLine).trimStart().charAt(0) === '|') endLine++;
-				
-				let formatted = formatTable(startLine, endLine - startLine, i => cm.getLine(i));
-				if (endLine < cm.lineCount()) {
-					formatted += '\n';
-				}
-				cm.replaceRange(formatted, {line: startLine, ch: 0}, {line: endLine, ch: 0})
-            });
-		}
+        const prettierVersion = prettier.formatWithCursor(
+          editor.getValue(),
+          {
+            parser: parser,
+            // plugins: prettierPlugins,
+            tabWidth: 2,
+            useTabs: false,
+            cursorOffset: editor.indexFromPos(editor.getCursor()),
+          },
+        )
 
-		return {
-			plugin: plugin,
+        editor.setValue(prettierVersion.formatted)
+
+        if (false === editor.somethingSelected()) {
+          editor.setCursor(editor.posFromIndex(prettierVersion.cursorOffset))
         }
+      })
     }
+
+    return {
+      plugin: plugin,
+    }
+  },
 }


### PR DESCRIPTION
![joplin-prettier](https://user-images.githubusercontent.com/24560368/118209606-80df9900-b49b-11eb-9f5c-d2ed35c3711f.gif)
