### PR TITLE
table navigation and format with shortcut

### DIFF
--- a/plugin.config.json
+++ b/plugin.config.json
@@ -1,5 +1,6 @@
 {
 	"extraScripts": [
-		"TableFormatter.ts"
+		"TableFormatter.ts",
+		"tableAutoFormatter/index.ts"
 	]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import joplin from 'api';
-import { ContentScriptType, MenuItemLocation } from 'api/types';
+import {ContentScriptType, MenuItemLocation, ToolbarButtonLocation} from 'api/types';
 
 joplin.plugins.register({
 	onStart: async function() {
@@ -13,5 +13,87 @@ joplin.plugins.register({
 		});
 		joplin.views.menuItems.create("Format Table", "formatTable", MenuItemLocation.Edit);
 		joplin.views.menuItems.create("Format Table Context", "formatTable", MenuItemLocation.EditorContextMenu);
+
+		await initTableAutoFormatter();
 	},
 });
+
+async function initTableAutoFormatter() {
+	await joplin.contentScripts.register(
+		ContentScriptType.CodeMirrorPlugin,
+		'auto_table_formatter',
+		'./tableAutoFormatter/index.js'
+	);
+
+	await joplin.commands.register({
+		name: 'auto_table_alignColumnLeft',
+		label: 'Align current column to left',
+		iconName: 'fas fa-align-left',
+		execute: async () => {
+			await joplin.commands.execute('editor.execCommand', {
+				name: 'auto_table_alignColumns',
+				args: [[':', '-']]
+			});
+		},
+	});
+
+	await joplin.commands.register({
+		name: 'auto_table_alignColumnRight',
+		label: 'Align current column to right',
+		iconName: 'fas fa-align-right',
+		execute: async () => {
+			await joplin.commands.execute('editor.execCommand', {
+				name: 'auto_table_alignColumns',
+				args: [['-', ':']]
+			});
+		},
+	});
+
+	await joplin.commands.register({
+		name: 'auto_table_alignColumnCenter',
+		label: 'Align current column to center',
+		iconName: 'fas fa-align-center',
+		execute: async () => {
+			await joplin.commands.execute('editor.execCommand', {
+				name: 'auto_table_alignColumns',
+				args: [[':', ':']]
+			});
+		},
+	});
+
+	await joplin.commands.register({
+		name: 'auto_table_alignColumnSlash',
+		label: 'Remove the alignment of current column',
+		iconName: 'fas fa-align-justify',
+		execute: async () => {
+			await joplin.commands.execute('editor.execCommand', {
+				name: 'auto_table_alignColumns',
+				args: [['-', '-']]
+			});
+		},
+	});
+
+	await joplin.views.toolbarButtons.create(
+		'auto_table_align-column-left',
+		'auto_table_alignColumnLeft',
+		ToolbarButtonLocation.EditorToolbar,
+	);
+
+	await joplin.views.toolbarButtons.create(
+		'auto_table_align-column-center',
+		'auto_table_alignColumnCenter',
+		ToolbarButtonLocation.EditorToolbar,
+	);
+
+	await joplin.views.toolbarButtons.create(
+		'auto_table_align-column-right',
+		'auto_table_alignColumnRight',
+		ToolbarButtonLocation.EditorToolbar,
+	);
+
+	await joplin.views.toolbarButtons.create(
+		'auto_table_align-column-slash',
+		'auto_table_alignColumnSlash',
+		ToolbarButtonLocation.EditorToolbar,
+	);
+}

--- a/src/tableAutoFormatter/index.ts
+++ b/src/tableAutoFormatter/index.ts
@@ -1,0 +1,52 @@
+import {navigateCell, insertColumn, insertRow, deleteColume} from "./tableCommands";
+import TableFormatterBridge from "./tableFormatterBridge";
+
+
+module.exports = {
+    default: function(_context) {
+        return {
+            plugin: function (CodeMirror) {
+                CodeMirror.defineOption("auto_table_tableFormatter", [], async function(cm, val, old) {
+                    if (old && old != CodeMirror.Init) {
+                        cm.off('keyup', tabPressed);
+                    }
+                    cm.on('keyup', tabPressed);
+
+                    const commandBridge = new TableFormatterBridge(cm);
+                    CodeMirror.defineExtension('auto_table_alignColumns', commandBridge.alignColumnsCommand.bind(commandBridge));
+                });
+
+                function tabPressed(cm, event) {
+                    if (event.code === 'Tab' && !event.shiftKey) {
+                        navigateCell(cm, true, false);
+                    } else if (event.code === 'Tab' && event.shiftKey) {
+                        navigateCell(cm, true, true);
+                    } else if (event.shiftKey && event.ctrlKey && !event.metaKey) {
+                        switch (event.code) {
+                            case 'ArrowLeft':
+                                insertColumn(cm, true);
+                                break;
+                            case 'ArrowRight':
+                                insertColumn(cm, false);
+                                break;
+                            case 'ArrowUp':
+                                insertRow(cm, true);
+                                break;
+                            case 'ArrowDown':
+                                insertRow(cm, false);
+                                break;
+                            case 'Backspace':
+                                deleteColume(cm);
+                                break;
+                            default:break;
+                        }
+                    }
+                }
+            },
+            codeMirrorOptions: { 'auto_table_tableFormatter': true },
+            assets: function() {
+                return [ ];
+            }
+        }
+    },
+}

--- a/src/tableAutoFormatter/markdownTableData.ts
+++ b/src/tableAutoFormatter/markdownTableData.ts
@@ -1,0 +1,19 @@
+// implemented by takumisoft68 at https://github.com/takumisoft68/vscode-markdown-table/blob/master/src/markdownTableData.ts
+
+export default class MarkdownTableData {
+    public readonly originalText: string;
+    public readonly aligns: [string, string][];
+    public readonly columns: string[];
+    public readonly cells: string[][];
+    public readonly leftovers: string[];
+    public readonly indent: string;
+
+    constructor(_text: string, _aligns: [string, string][], _columns: string[], _cells: string[][], _leftovers: string[], _indent: string) {
+        this.originalText = _text;
+        this.aligns = _aligns;
+        this.columns = _columns;
+        this.cells = _cells;
+        this.leftovers = _leftovers;
+        this.indent = _indent;
+    }
+};

--- a/src/tableAutoFormatter/markdownTableUtility.ts
+++ b/src/tableAutoFormatter/markdownTableUtility.ts
@@ -1,0 +1,151 @@
+// implemented by takumisoft68 at https://github.com/takumisoft68/vscode-markdown-table/blob/master/src/markdownTableUtility.ts
+
+/**
+ * 1行分の文字列を列データ配列に分解する
+ * 指定した列数に満たない行は 埋め文字 で埋める
+ * @param linestr 1行分の文字列
+ * @param columnNum 列数
+ * @param fillstr 埋め文字
+ */
+export function splitline(linestr: string, columnNum: number, fillstr: string = '') {
+    // 先頭と末尾の|を削除
+    linestr = linestr.trim();
+    if (linestr.startsWith('|')) {
+        linestr = linestr.slice(1);
+    }
+    if (linestr.endsWith('|')) {
+        linestr = linestr.slice(0, -1);
+    }
+
+    // |で分割
+    let linedatas: string[] = [];
+    let startindex = 0;
+    let endindex = 0;
+    let isEscaping = false;
+    let isInInlineCode = false;
+    for (let i = 0; i < linestr.length; ++i) {
+        if (isEscaping) {
+            // エスケープ文字の次の文字は|かどうか判定しない
+            isEscaping = false;
+            endindex++;
+            continue;
+        }
+
+        const chara = linestr.charAt(i);
+        if (chara === '\`') {
+            // `の間はインラインコード
+            isInInlineCode = !isInInlineCode;
+            endindex++;
+            continue;
+        }
+        if (isInInlineCode) {
+            // インラインコード中は|かどうか判定しない
+            endindex++;
+            continue;
+        }
+
+        if (chara === '\\') {
+            // \はエスケープ文字
+            isEscaping = true;
+            endindex++;
+            continue;
+        }
+
+        if (chara !== '|') {
+            // | 以外だったら継続
+            endindex++;
+            continue;
+        }
+
+        // | だったら分割
+        let cellstr = linestr.slice(startindex, endindex);
+        linedatas.push(cellstr);
+        startindex = i + 1;
+        endindex = i + 1;
+    }
+    linedatas.push(linestr.slice(startindex));
+
+    // データ数分を''で埋めておく
+    let datas: string[] = new Array(columnNum).fill(fillstr);
+    // 行文字列から取得したデータに置き換える
+    for (let i = 0; i < linedatas.length; i++) {
+        datas[i] = linedatas[i];
+    }
+    return datas;
+};
+
+
+
+// 半角文字は1文字、全角文字は2文字として文字数をカウントする
+export function getLen(str: string): number {
+    let length = 0;
+    for (let i = 0; i < str.length; i++) {
+        let chp = str.codePointAt(i);
+        if (chp === undefined) {
+            continue;
+        }
+        let chr = chp as number;
+        if (doesUse0Space(chr)) {
+            length += 0;
+        }
+        else if (doesUse3Spaces(chr)) {
+            length += 3;
+        }
+        else if (doesUse2Spaces(chr)) {
+            // 全角文字の場合は2を加算
+            length += 2;
+        }
+        else {
+            //それ以外の文字の場合は1を加算
+            length += 1;
+        }
+
+        let chc = str.charCodeAt(i);
+        if (chc >= 0xD800 && chc <= 0xDBFF) {
+            // サロゲートペアの時は1文字読み飛ばす
+            i++;
+        }
+
+        // if( (chr >= 0x00 && chr <= 0x80) ||
+        //     (chr >= 0xa0 && chr <= 0xff) ||
+        //     (chr === 0xf8f0) ||
+        //     (chr >= 0xff61 && chr <= 0xff9f) ||
+        //     (chr >= 0xf8f1 && chr <= 0xf8f3)){
+        //     //半角文字の場合は1を加算
+        //     length += 1;
+        // }else{
+        //     //それ以外の文字の場合は2を加算
+        //     length += 2;
+        // }
+    }
+    //結果を返す
+    return length;
+};
+
+function doesUse0Space(charCode: number): boolean {
+    if ((charCode === 0x02DE) ||
+        (charCode >= 0x0300 && charCode <= 0x036F) ||
+        (charCode >= 0x0483 && charCode <= 0x0487) ||
+        (charCode >= 0x0590 && charCode <= 0x05CF)) {
+        return true;
+    }
+    return false;
+}
+
+function doesUse2Spaces(charCode: number): boolean {
+    if ((charCode >= 0x2480 && charCode <= 0x24FF) ||
+        (charCode >= 0x2600 && charCode <= 0x27FF) ||
+        (charCode >= 0x2900 && charCode <= 0x2CFF) ||
+        (charCode >= 0x2E00 && charCode <= 0xFF60) ||
+        (charCode >= 0xFFA0)) {
+        return true;
+    }
+    return false;
+}
+
+function doesUse3Spaces(charCode: number): boolean {
+    if (charCode >= 0x1F300 && charCode <= 0x1FBFF) {
+        return true;
+    }
+    return false;
+}

--- a/src/tableAutoFormatter/markdowntable.ts
+++ b/src/tableAutoFormatter/markdowntable.ts
@@ -1,0 +1,390 @@
+// code implemented by takumisoft68 at https://github.com/takumisoft68/vscode-markdown-table/blob/master/src/markdowntable.tssss
+
+import MarkdownTableData from './markdownTableData';
+import * as Utility from './markdownTableUtility';
+
+
+/**
+ * テーブルを表すマークダウンテキストを MarkdownTableData に変換する
+ * @param tableText テーブルを表すマークダウンテキスト
+ */
+export function stringToTableData(tableText: string): MarkdownTableData {
+    let lines = tableText.split(/\r\n|\n|\r/);
+
+    let getIndent = (linestr: string) => {
+        if (linestr.trim().startsWith('|')) {
+            let linedatas = linestr.split('|');
+            return linedatas[0];
+        }
+        else {
+            return '';
+        }
+    };
+
+    // 1行目
+    let columns = Utility.splitline(lines[0], 0);
+    let columnNum = columns.length;
+    let indent = getIndent(lines[0]);
+
+    // 2行目の寄せ記号
+    let aligns: [string, string][] = new Array();
+    let aligndatas = Utility.splitline(lines[1], columnNum, '---').map((v) => v.trim());
+    for (let i = 0; i < columnNum; i++) {
+        let celldata = aligndatas[i];
+        aligns[i] = [celldata[0], celldata.slice(-1)];
+    }
+
+    // セルの値を取得
+    let cells: string[][] = new Array();
+    let leftovers: string[] = new Array();
+    let cellrow = -1;
+    for (let row = 2; row < lines.length; row++) {
+        cellrow++;
+
+        let linedatas = Utility.splitline(lines[row], columnNum);
+        cells[cellrow] = linedatas.slice(0, columnNum);
+
+        // あまりデータを収集する
+        leftovers[cellrow] = '';
+        if (linedatas.length > columnNum) {
+            let leftoverdatas = linedatas.slice(columnNum, linedatas.length);
+            leftovers[cellrow] = leftoverdatas.join('|');
+        }
+    }
+
+    return new MarkdownTableData(tableText, aligns, columns, cells, leftovers, indent);
+}
+
+/**
+ * タブ区切りテキストを MarkdownTableData に変換する
+ * @param tableText タブ区切りテキスト
+ */
+export function tsvToTableData(tsvText: string): MarkdownTableData {
+    // 入力データを行ごとに分割する
+    let lines = tsvText.split(/\r\n|\n|\r/);
+    // カラムデータ
+    let columns: string[] = new Array();
+    let columntexts = lines[0].split('\t');
+    // カラム数
+    let columnCount = columntexts.length;
+
+    for (let i = 0; i < columnCount; i++) {
+        columns[i] = columntexts[i].trim();
+    }
+
+    // 入力データから改行とタブで分割した2次元配列を生成する
+    let cells: string[][] = new Array();
+    // カラム数よりもはみ出たデータ
+    let leftovers: string[] = new Array();
+    for (let row = 1; row < lines.length; row++) {
+        // 各セルの値
+        cells[row - 1] = new Array();
+        // 行内のデータが足りない場合に備えて空白文字で埋める
+        for (let column = 0; column < columnCount; column++) {
+            cells[row - 1][column] = ' ';
+        }
+
+        // 余りデータを初期化
+        leftovers[row - 1] = '';
+
+        // 行データをタブで分割
+        let lineValues = lines[row].split('\t');
+
+        // 実際の値に置き換える
+        for (let column = 0; column < lineValues.length; column++) {
+            if (column >= columnCount) {
+                // カラムヘッダーよりも多い場合ははみ出しデータ配列に保存
+                leftovers[row - 1] += '\t' + lineValues[column];
+                continue;
+            }
+            cells[row - 1][column] = lineValues[column].trim();
+        }
+    }
+
+    // 表の寄せ記号
+    let aligns: [string, string][] = new Array();
+    for (let column = 0; column < columnCount; column++) {
+        // 全部左寄せ
+        aligns[column] = [':', '-'];
+    }
+
+    const table = new MarkdownTableData("", aligns, columns, cells, leftovers, '');
+    return new MarkdownTableData(toFormatTableStr(table), aligns, columns, cells, leftovers, '');
+}
+
+
+/**
+ * MarkdownTableData に行を追加
+ * @param tableData
+ * @param insertAt
+ * @returns
+ */
+export function insertRow(tableData: MarkdownTableData, insertAt: number): MarkdownTableData {
+    const columns = tableData.columns;
+    const aligns = tableData.aligns;
+    const cells = tableData.cells;
+    const leftovers = tableData.leftovers;
+    const column_num = tableData.columns.length;
+    const indent = tableData.indent;
+
+    cells.splice(insertAt, 0, Array.from({ length: column_num }, () => '  '));
+    leftovers.splice(insertAt, 0, '');
+
+    const table = new MarkdownTableData("", aligns, columns, cells, leftovers, indent);
+    return new MarkdownTableData(toFormatTableStr(table), aligns, columns, cells, leftovers, indent);
+}
+
+export function deleteColumn(tableData: MarkdownTableData, deleteAt: number): MarkdownTableData {
+    let columns = tableData.columns;
+    let aligns = tableData.aligns;
+    let cells = tableData.cells;
+    let leftovers = tableData.leftovers;
+    let column_num = tableData.columns.length;
+    let indent = tableData.indent;
+
+    columns.splice(deleteAt, 1);
+    aligns.splice(deleteAt, 1);
+    for (let i = 0; i < cells.length; i++) {
+        cells[i].splice(deleteAt, 1);
+    }
+
+    const table = new MarkdownTableData("", aligns, columns, cells, leftovers, indent);
+    return new MarkdownTableData(toFormatTableStr(table), aligns, columns, cells, leftovers, indent);
+}
+
+export function insertColumn(tableData: MarkdownTableData, insertAt: number): MarkdownTableData {
+    let columns = tableData.columns;
+    let aligns = tableData.aligns;
+    let cells = tableData.cells;
+    let leftovers = tableData.leftovers;
+    let column_num = tableData.columns.length;
+    let indent = tableData.indent;
+
+    columns.splice(insertAt, 0, '');
+    aligns.splice(insertAt, 0, ['-', '-']);
+    for (let i = 0; i < cells.length; i++) {
+        cells[i].splice(insertAt, 0, '');
+    }
+
+    const table = new MarkdownTableData("", aligns, columns, cells, leftovers, indent);
+    return new MarkdownTableData(toFormatTableStr(table), aligns, columns, cells, leftovers, indent);
+}
+
+
+
+export function toFormatTableStr(tableData: MarkdownTableData): string {
+    let alignData = true;
+    let alignHeader = true;
+    let columnNum = tableData.columns.length;
+
+    // 各列の最大文字数を調べる
+    let maxWidths: number[] = new Array();
+    // コラムヘッダーの各項目の文字数
+    for (let i = 0; i < tableData.columns.length; i++) {
+        let cellLength = Utility.getLen(tableData.columns[i].trim());
+        // 表の寄せ記号行は最短で半角3文字なので、各セル最低でも半角3文字
+        maxWidths[i] = (3 > cellLength) ? 3 : cellLength;
+    }
+
+    for (let row = 0; row < tableData.cells.length; row++) {
+        let cells = tableData.cells[row];
+        for (let i = 0; i < cells.length; i++) {
+            if (i > columnNum) { break; }
+            let cellLength = Utility.getLen(cells[i].trim());
+            maxWidths[i] = (maxWidths[i] > cellLength) ? maxWidths[i] : cellLength;
+        }
+    }
+
+    let formatted: string[] = new Array();
+
+    // 列幅をそろえていく
+    for (let row = 0; row < tableData.cells.length; row++) {
+        formatted[row] = '';
+        formatted[row] += tableData.indent;
+        let cells = tableData.cells[row];
+        for (let i = 0; i < columnNum; i++) {
+            let celldata = '';
+            if (i < cells.length) {
+                celldata = cells[i].trim();
+            }
+            let celldata_length = Utility.getLen(celldata);
+
+            // | の後にスペースを入れる
+            formatted[row] += '| ';
+            if (alignData) {
+                let [front, end] = tableData.aligns[i];
+                if (front === ':' && end === ':') {
+                    // 中央ぞろえ
+                    for (let n = 0; n < (maxWidths[i] - celldata_length) / 2 - 0.5; n++) {
+                        formatted[row] += ' ';
+                    }
+                    formatted[row] += celldata;
+                    for (let n = 0; n < (maxWidths[i] - celldata_length) / 2; n++) {
+                        formatted[row] += ' ';
+                    }
+                }
+                else if (front === '-' && end === ':') {
+                    // 右揃え
+                    for (let n = 0; n < maxWidths[i] - celldata_length; n++) {
+                        formatted[row] += ' ';
+                    }
+                    formatted[row] += celldata;
+                }
+                else {
+                    // 左揃え
+                    formatted[row] += celldata;
+                    for (let n = 0; n < maxWidths[i] - celldata_length; n++) {
+                        formatted[row] += ' ';
+                    }
+                }
+            }
+            else {
+                // データ
+                formatted[row] += celldata;
+                // 余白を半角スペースで埋める
+                for (let n = celldata_length; n < maxWidths[i]; n++) {
+                    formatted[row] += ' ';
+                }
+            }
+            // | の前にスペースを入れる
+            formatted[row] += ' ';
+        }
+        formatted[row] += '|';
+
+        // あまりデータを末尾に着ける
+        if (tableData.leftovers[row].length > 0) {
+            formatted[row] += tableData.leftovers[row];
+        }
+    }
+
+    // 1行目を成形する
+    let columnHeader = '';
+    columnHeader += tableData.indent;
+    for (let i = 0; i < columnNum; i++) {
+        const columnText = tableData.columns[i].trim();
+        const columnHeader_length = Utility.getLen(columnText);
+
+        columnHeader += '| ';
+        if (alignHeader) {
+            let [front, end] = tableData.aligns[i];
+            if (front === ':' && end === ':') {
+                // 中央ぞろえ
+                for (let n = 0; n < (maxWidths[i] - columnHeader_length) / 2 - 0.5; n++) {
+                    columnHeader += ' ';
+                }
+                columnHeader += columnText;
+                for (let n = 0; n < (maxWidths[i] - columnHeader_length) / 2; n++) {
+                    columnHeader += ' ';
+                }
+            }
+            else if (front === '-' && end === ':') {
+                // 右揃え
+                for (let n = 0; n < maxWidths[i] - columnHeader_length; n++) {
+                    columnHeader += ' ';
+                }
+                columnHeader += columnText;
+            }
+            else {
+                // 左揃え
+                columnHeader += columnText;
+                for (let n = 0; n < maxWidths[i] - columnHeader_length; n++) {
+                    columnHeader += ' ';
+                }
+            }
+
+        }
+        else {
+            columnHeader += columnText;
+            // 余白を-で埋める
+            for (let n = columnHeader_length; n < maxWidths[i]; n++) {
+                columnHeader += ' ';
+            }
+        }
+        columnHeader += ' ';
+    }
+    columnHeader += '|';
+
+
+    // 2行目を成形する
+    let tablemark = '';
+    tablemark += tableData.indent;
+    for (let i = 0; i < columnNum; i++) {
+        let [front, end] = tableData.aligns[i];
+        tablemark += '| ' + front;
+
+        // 余白を-で埋める
+        for (let n = 1; n < maxWidths[i] - 1; n++) {
+            tablemark += '-';
+        }
+        tablemark += end + ' ';
+    }
+    tablemark += '|';
+
+    formatted.splice(0, 0, columnHeader);
+    formatted.splice(1, 0, tablemark);
+
+    return formatted.join('\r\n');
+}
+
+
+
+// return [line, character]
+export function getPositionOfCell(tableData: MarkdownTableData, cellRow: number, cellColumn: number): [number, number] {
+    let line = (cellRow <= 0) ? 0 : cellRow;
+
+    let lines = tableData.originalText.split(/\r\n|\n|\r/);
+    let linestr = lines[cellRow];
+
+    let cells = Utility.splitline(linestr, tableData.columns.length);
+
+    let character = 0;
+    character += tableData.indent.length;
+    character += 1;
+    for (let i = 0; i < cellColumn; i++) {
+        character += cells[i].length;
+        character += 1;
+    }
+
+    return [line, character];
+}
+
+// return [row, column]
+export function getCellAtPosition(tableData: MarkdownTableData, line: number, character: number): [number, number] {
+    let row = (line <= 0) ? 0 : line;
+
+    let lines = tableData.originalText.split(/\r\n|\n|\r/);
+    let linestr = lines[row];
+
+    let cells = Utility.splitline(linestr, tableData.columns.length);
+
+    let column = -1;
+    let cell_end = tableData.indent.length;
+    for (let cell of cells) {
+        column++;
+        cell_end += 1 + cell.length;
+
+        if (character <= cell_end) {
+            break;
+        }
+    }
+
+    return [row, column];
+}
+
+export function getCellData(tableData: MarkdownTableData, cellRow: number, cellColumn: number): string {
+    if (cellRow === 0) {
+        return (tableData.columns.length > cellColumn) ? tableData.columns[cellColumn] : "";
+    }
+    if (cellRow === 1) {
+        if (tableData.aligns.length <= cellColumn) {
+            return "---";
+        }
+        let [front, end] = tableData.aligns[cellColumn];
+        return ' ' + front + '-' + end + ' ';
+    }
+    if (cellRow >= tableData.cells.length + 2) {
+        return "";
+    }
+
+    return tableData.cells[cellRow - 2][cellColumn];
+}

--- a/src/tableAutoFormatter/tableCommands.ts
+++ b/src/tableAutoFormatter/tableCommands.ts
@@ -1,0 +1,369 @@
+// some code from https://github.com/takumisoft68/vscode-markdown-table/blob/master/src/commands.ts
+import * as mdt from './markdowntable';
+
+export function alignColumns(cm, alignMark: [string, string]) {
+    // ドキュメント取得
+    const doc = cm.getDoc();
+    // 選択範囲取得
+    const cur_selection = doc.listSelections()[0];
+    // 選択範囲の始まり行
+    const currentLine = doc.getLine(cur_selection.anchor.line);
+
+    // テーブル内ではなかったら終了
+    if (!currentLine.trim().startsWith('|')) {
+        return;
+    }
+
+    // 表を探す
+    const parseResult = parseSelection(doc, cur_selection);
+    const startLine = parseResult[0],
+        endLine = parseResult[1],
+        table_selection = parseResult[2],
+        table_text = parseResult[3];
+
+    // テーブルをTableDataにシリアライズ
+    let tableData = mdt.stringToTableData(table_text);
+    if (tableData.aligns[0][0] === undefined) {
+        return;
+    }
+
+    // 選択セルを取得
+    const [startline, startcharacter] = [cur_selection.anchor.line - startLine, cur_selection.anchor.ch];
+    const [startRow, startColumn] = mdt.getCellAtPosition(tableData, startline, startcharacter);
+    const [endline, endcharacter] = [cur_selection.head.line - startLine, cur_selection.head.ch];
+    const [endRow, endColumn] = mdt.getCellAtPosition(tableData, endline, endcharacter);
+
+    // 選択範囲の列のAlignを変更する
+    if (startRow === endRow) {
+        // 選択範囲の開始位置と終了位置が同じ行内の場合
+        for (let column = startColumn; column <= endColumn; column++) {
+            tableData.aligns[column] = alignMark;
+        }
+    }
+    else if (startRow + 1 === endRow) {
+        // 選択範囲が2行にまたがる場合
+        for (let column = startColumn; column <= tableData.columns.length; column++) {
+            tableData.aligns[column] = alignMark;
+        }
+        for (let column = 0; column <= endColumn; column++) {
+            tableData.aligns[column] = alignMark;
+        }
+    }
+    else {
+        // 選択範囲が3行以上にまたがる場合はすべての列が対象
+        for (let column = 0; column < tableData.columns.length; column++) {
+            tableData.aligns[column] = alignMark;
+        }
+    }
+
+    // テーブルをフォーマットした文字列を取得
+    const newTableText = mdt.toFormatTableStr(tableData);
+
+    //エディタ選択範囲にテキストを反映
+    doc.replaceRange(newTableText, table_selection.anchor, table_selection.head);
+
+    // 元のカーソル選択位置を計算
+    const [anchorline, anchorcharacter] = [cur_selection.anchor.line - startLine, cur_selection.anchor.ch];
+    // 元のカーソル選択位置のセルを取得
+    const [anchorRow, anchorColumn] = mdt.getCellAtPosition(tableData, anchorline, anchorcharacter,);
+
+    const tableStrFormatted = mdt.toFormatTableStr(tableData);
+    const tableDataFormatted = mdt.stringToTableData(tableStrFormatted);
+
+    // 新しいカーソル位置をフォーマット後のテキストから計算
+    const [newline, newcharacter] = mdt.getPositionOfCell(tableDataFormatted, anchorRow, anchorColumn);
+    const newPosition = {
+        'line': table_selection.anchor.line + newline,
+        'ch': table_selection.anchor.ch + newcharacter + 1
+    };
+
+    // カーソル位置を移動
+    doc.setSelection(newPosition);
+};
+
+export function deleteColume(cm) {
+    if (!isCurrSelectionInTable(cm)) {
+        return;
+    }
+
+    // ドキュメント取得
+    const doc = cm.getDoc();
+    // 選択範囲取得
+    const cur_selection = doc.listSelections()[0];
+    // if (!doc.getSelection().isEmpty) {
+    //     return;
+    // }
+
+    // 表を探す
+    const parseResult = parseSelection(doc, cur_selection);
+    const startLine = parseResult[0],
+        endLine = parseResult[1],
+        table_selection = parseResult[2],
+        table_text = parseResult[3];
+
+    // 元のカーソル位置を取得
+    const [prevline, prevcharacter] = [cur_selection.head.line - startLine, cur_selection.head.ch];
+
+    // テーブルをフォーマット
+    const tableData = mdt.stringToTableData(table_text);
+
+    if (tableData.columns.length == 1) {
+        return;
+    }
+
+    // 元のカーソル位置のセルを取得
+    const [prevRow, prevColumn] = mdt.getCellAtPosition(tableData, prevline, prevcharacter);
+
+    // 删除位置
+    const newTableData = mdt.deleteColumn(tableData, prevColumn);
+    const tableStrFormatted = mdt.toFormatTableStr(newTableData);
+    const tableDataFormatted = mdt.stringToTableData(tableStrFormatted);
+
+    //エディタ選択範囲にテキストを反映
+    doc.replaceRange(tableStrFormatted, table_selection.anchor, table_selection.head);
+
+    // 新しいカーソル位置を計算
+    // character の +1 は表セル内の|とデータの間の半角スペース分
+    let newColumn = prevColumn;
+    if (newColumn >= tableDataFormatted.columns.length) {
+        newColumn = tableDataFormatted.columns.length - 1;
+    }
+    const [newline, newcharacter] = mdt.getPositionOfCell(tableDataFormatted, prevRow, newColumn);
+    const newPosition = {
+        'line': table_selection.anchor.line + newline,
+        'ch': table_selection.anchor.ch + newcharacter + 1
+    };
+
+    // カーソル位置を移動
+    doc.setSelection(newPosition);
+}
+
+export function insertRow(cm, isAbove: boolean) {
+    if (!isCurrSelectionInTable(cm)) {
+        return;
+    }
+
+    // ドキュメント取得
+    const doc = cm.getDoc();
+    // 選択範囲取得
+    const cur_selection = doc.listSelections()[0];
+
+    // 表を探す
+    const parseResult = parseSelection(doc, cur_selection);
+    const startLine = parseResult[0],
+        endLine = parseResult[1],
+        table_selection = parseResult[2],
+        table_text = parseResult[3];
+
+    // 元のカーソル位置を取得
+    const [prevline, prevcharacter] = [cur_selection.head.line - startLine, cur_selection.head.ch];
+
+    // テーブルをフォーマット
+    const tableData = mdt.stringToTableData(table_text);
+
+    // 元のカーソル位置のセルを取得
+    const [prevRow, prevColumn] = mdt.getCellAtPosition(tableData, prevline, prevcharacter);
+
+    // 挿入位置
+    const insertPosition = isAbove ? prevRow - 1 : prevRow;
+
+    const newTableData = mdt.insertRow(tableData, insertPosition - 1 /* index from 0 here */);
+    const tableStrFormatted = mdt.toFormatTableStr(newTableData);
+    const tableDataFormatted = mdt.stringToTableData(tableStrFormatted);
+
+    //エディタ選択範囲にテキストを反映
+    doc.replaceRange(tableStrFormatted, table_selection.anchor, table_selection.head);
+
+    // 新しいカーソル位置を計算
+    // character の +1 は表セル内の|とデータの間の半角スペース分
+    const newRow = insertPosition + 1;
+    const [newline, newcharacter] = mdt.getPositionOfCell(tableDataFormatted, newRow, prevColumn);
+    const newPosition = {
+        'line': table_selection.anchor.line + newline,
+        'ch': table_selection.anchor.ch + newcharacter + 1
+    };
+
+    // カーソル位置を移動
+    doc.setSelection(newPosition);
+}
+
+export function insertColumn(cm, isLeft: boolean) {
+    if (!isCurrSelectionInTable(cm)) {
+        return;
+    }
+
+    // ドキュメント取得
+    const doc = cm.getDoc();
+    // 選択範囲取得
+    const cur_selection = doc.listSelections()[0];
+    // if (!doc.getSelection().isEmpty) {
+    //     return;
+    // }
+
+    // 表を探す
+    const parseResult = parseSelection(doc, cur_selection);
+    const startLine = parseResult[0],
+          endLine = parseResult[1],
+          table_selection = parseResult[2],
+          table_text = parseResult[3];
+
+    // 元のカーソル位置を取得
+    const [prevline, prevcharacter] = [cur_selection.head.line - startLine, cur_selection.head.ch];
+
+    // テーブルをフォーマット
+    const tableData = mdt.stringToTableData(table_text);
+
+    // 元のカーソル位置のセルを取得
+    const [prevRow, prevColumn] = mdt.getCellAtPosition(tableData, prevline, prevcharacter);
+
+    // 挿入位置
+    const insertPosition = isLeft ? prevColumn : prevColumn + 1;
+
+    const newTableData = mdt.insertColumn(tableData, insertPosition);
+    const tableStrFormatted = mdt.toFormatTableStr(newTableData);
+    const tableDataFormatted = mdt.stringToTableData(tableStrFormatted);
+
+    //エディタ選択範囲にテキストを反映
+    doc.replaceRange(tableStrFormatted, table_selection.anchor, table_selection.head);
+
+    // 新しいカーソル位置を計算
+    // character の +1 は表セル内の|とデータの間の半角スペース分
+    const newColumn = insertPosition;
+    const [newline, newcharacter] = mdt.getPositionOfCell(tableDataFormatted, prevRow, newColumn);
+    const newPosition = {
+        'line': table_selection.anchor.line + newline,
+        'ch': table_selection.anchor.ch + newcharacter + 1
+    };
+
+    // カーソル位置を移動
+    doc.setSelection(newPosition);
+};
+
+/**
+ * merge navigateNextCell() and navigatePrevCell() into one function
+ * migrate from vscode editor to codemirror
+ */
+export function navigateCell(cm, withFormat: boolean, prev=false) {
+    if (!isCurrSelectionInTable(cm)) {
+        return;
+    }
+
+    // ドキュメント取得
+    const doc = cm.getDoc();
+    // 選択範囲取得
+    const cur_selection = doc.listSelections()[0];
+
+    // 表を探す
+    const parseResult = parseSelection(doc, cur_selection);
+    const startLine = parseResult[0],
+        endLine = parseResult[1],
+        table_selection = parseResult[2],
+        table_text = parseResult[3];
+
+    // 元のカーソル位置を取得
+    const [prevline, prevcharacter] = [cur_selection.head.line - startLine, cur_selection.head.ch];
+
+    // テーブルをTableDataにシリアライズ
+    let tableData = mdt.stringToTableData(table_text);
+    if (tableData.aligns[0][0] === undefined) {
+        return;
+    }
+
+    // 元のカーソル位置のセルを取得
+    const [prevRow, prevColumn] = mdt.getCellAtPosition(tableData, prevline, prevcharacter);
+
+    // only used for navigating forward ->
+    let isNextRow = false;
+
+    // return if there is no previous cell when navigating backward <-
+    if (prev) {
+        // 先頭セルだったら何もしない
+        if (prevColumn <= 0 && prevRow <= 0) {
+            return;
+        }
+    } else {  // append a new line if necessary when navigating forward ->
+        // 次のセルが新しい行になるかどうか
+        isNextRow = (prevColumn + 1 >= tableData.columns.length);
+        const isInsertNewRow = (
+            // カラム行、または寄せ記号行の場合は3行目を作成する
+            (prevRow <= 1 && tableData.cells.length === 0) ||
+            // 現在の行が最終行で、かつ次の行に進む場合は末尾に1行追加する
+            (isNextRow && prevRow >= tableData.cells.length + 1)
+        );
+
+        // 次の行が必要なら追加する
+        if (isInsertNewRow === true) {
+            tableData = mdt.insertRow(tableData, tableData.cells.length);
+        }
+    }
+
+    // テーブルをフォーマットしたテキストを取得
+    const new_text = withFormat ? mdt.toFormatTableStr(tableData) : tableData.originalText;
+    const tableDataFormatted = mdt.stringToTableData(new_text);
+
+    //エディタ選択範囲にテキストを反映
+    doc.replaceRange(new_text, table_selection.anchor, table_selection.head);
+
+    // 新しいカーソル位置を計算
+    // character の +1 は表セル内の|とデータの間の半角スペース分
+    let newColumn, newRow;
+    if (prev) {
+        newColumn = (prevColumn > 0) ? prevColumn - 1 : tableDataFormatted.columns.length - 1;
+        newRow = (prevColumn > 0) ? prevRow : prevRow - 1;
+    } else {
+        newColumn = (isNextRow === true) ? 0 : prevColumn + 1;
+        newRow = (isNextRow === true) ? prevRow + 1 : prevRow;
+    }
+    const [newline, newcharacter] = mdt.getPositionOfCell(tableDataFormatted, newRow, newColumn);
+    const newPosition = {
+        'line': table_selection.anchor.line + newline,
+        'ch': table_selection.anchor.ch + newcharacter + 1
+    };
+
+    // カーソル位置を移動
+    doc.setSelection(newPosition);
+}
+
+function isInTable(text: string) :boolean {
+    return text.trim().startsWith('|');
+}
+
+
+export function isCurrSelectionInTable(cm) :boolean {
+    const doc = cm.getDoc();
+    const cur_selection = doc.listSelections()[0];
+
+    let startLine = cur_selection.anchor.line;
+    const line_text = doc.getLine(startLine);
+    return isInTable(line_text);
+}
+
+function parseSelection(doc, cur_selection) {
+    // 表を探す
+    let startLine = cur_selection.anchor.line;
+    let endLine = cur_selection.anchor.line;
+
+    while (startLine - 1 >= 0) {
+        const line_text = doc.getLine(startLine);
+        if (!isInTable(line_text)) {
+            startLine++;
+            break;
+        }
+        startLine--;
+    }
+    while (endLine + 1 < doc.lineCount()) {
+        const line_text = doc.getLine(endLine + 1);
+        if (!isInTable(line_text)) {
+            break;
+        }
+        endLine++;
+    }
+    const table_selection = {
+        'anchor': {'line': startLine, 'ch': 0},
+        'head': {'line': endLine, 'ch': 10000}
+    };
+    doc.setSelection(table_selection.anchor, table_selection.head);
+    const table_text = doc.getSelection();
+
+    return [startLine, endLine, table_selection, table_text];
+}

--- a/src/tableAutoFormatter/tableFormatterBridge.ts
+++ b/src/tableAutoFormatter/tableFormatterBridge.ts
@@ -1,0 +1,29 @@
+import {alignColumns, deleteColume, insertColumn, insertRow} from "./tableCommands";
+
+export default class TableFormatterBridge {
+    constructor(private readonly editor) {}
+    private readonly doc = this.editor.getDoc();
+    insertColumnLeft() {
+        insertColumn(this.editor, true);
+    }
+
+    insertColumnRight() {
+        insertColumn(this.editor, false);
+    }
+
+    insertRowAbove() {
+        insertRow(this.editor, true);
+    }
+
+    insertRowBelow() {
+        insertRow(this.editor, false);
+    }
+
+    deleteColumn() {
+        deleteColume(this.editor);
+    }
+
+    alignColumnsCommand(options) {
+        alignColumns(this.editor, options);
+    }
+}


### PR DESCRIPTION
This is part of https://github.com/SeptemberHX/joplin-plugin-enhancement. Pull it to this repo so that others can benefit it without additional features in joplin-plugin-enhancement.

### Added Feature:

Auto add row/column, delete column, and format table.

> This part mainly comes from [takumisoft68: vscode-markdown-table](https://github.com/takumisoft68/vscode-markdown-table). Please refer to it for the feature description.
> I just convert the code from vscode's editor to joplin's codemirror. :)

Because I have no idea how to create a context menu, currently all the operations are triggered by shortcut:

|          Function          |          Shutcut          |
| :------------------------: | :-----------------------: |
|  Insert a row above/below  |  ctrl + shift + up/down   |
| Insert a column left/right | ctrl + shift + left/right |
|   Delete current column    | ctrl + shift + backspace  |
| Navigate to previous cell  |            tab            |
|   Navigate to next cell    |        shift + tab        |

1. It will automatically format your table code for alignment when navigation between cells with `tab`
2. A new line is appended when trying to navigate to next cell from the last cell

> Table column colorize from the plugin: [hieuthi/joplin-plugin-markdown-table-colorize](https://github.com/hieuthi/joplin-plugin-markdown-table-colorize)

![tableFormatter](https://i.imgur.com/mqHdvTm.gif)
